### PR TITLE
Add OpenAI File Search Tool with Default Integration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -30,6 +30,9 @@ LANGFUSE_BASEURL="https://cloud.langfuse.com" # 🇪🇺 EU region, use "https:/
 # OpenAI API Key
 OPENAI_API_KEY="sk-..."
 
+# OpenAI Vectorstore ID for file search
+OPENAI_VECTORSTORE_ID="vs_68c6a2b65df88191939f503958af019e"
+
 # Fireworks API Key (Only to replace o3-mini with deepseek-r1)
 FIREWORKS_KEY="sk-..."
 

--- a/app/(chat)/api/chat/route.ts
+++ b/app/(chat)/api/chat/route.ts
@@ -282,6 +282,8 @@ export async function POST(request: NextRequest) {
     // else if (selectedTool === 'reason') explicitlyRequestedTool = 'reasonSearch';
     else if (selectedTool === 'webSearch')
       explicitlyRequestedTools = ['webSearch'];
+    else if (selectedTool === 'fileSearch')
+      explicitlyRequestedTools = ['fileSearch'];
     else if (selectedTool === 'generateImage')
       explicitlyRequestedTools = ['generateImage'];
     else if (selectedTool === 'createDocument')
@@ -333,6 +335,10 @@ export async function POST(request: NextRequest) {
         activeTools = activeTools.filter(
           (tool: ToolName) => tool !== 'deepResearch',
         );
+      }
+      // Ensure fileSearch is available by default when tools are enabled
+      if (!activeTools.includes('fileSearch')) {
+        activeTools = [...activeTools, 'fileSearch'];
       }
     }
 

--- a/lib/ai/providers.ts
+++ b/lib/ai/providers.ts
@@ -66,9 +66,17 @@ export const getModelProviderOptions = (
   | Record<string, never> => {
   const model = getModelDefinition(providerModelId);
   if (model.owned_by === 'openai') {
+    const fileSearchTool = openai.tools.fileSearch({
+      vectorStoreIds: [
+        process.env.OPENAI_VECTORSTORE_ID ||
+          'vs_68c6a2b65df88191939f503958af019e',
+      ],
+    });
+
     if (model.features?.reasoning) {
       return {
         openai: {
+          tools: { file_search: fileSearchTool },
           reasoningSummary: 'auto',
           ...(model.id === 'openai/gpt-5' ||
           model.id === 'openai/gpt-5-mini' ||
@@ -78,7 +86,7 @@ export const getModelProviderOptions = (
         } satisfies OpenAIResponsesProviderOptions,
       };
     } else {
-      return { openai: {} };
+      return { openai: { tools: { file_search: fileSearchTool } } };
     }
   } else if (model.owned_by === 'anthropic') {
     if (model.features?.reasoning) {

--- a/lib/ai/tools/file-search.ts
+++ b/lib/ai/tools/file-search.ts
@@ -1,0 +1,23 @@
+import { openai } from '@ai-sdk/openai';
+import type { StreamWriter } from '../types';
+
+// OpenAI Vectorstore File Search tool wrapper
+// Uses env `OPENAI_VECTORSTORE_ID` with a sensible default fallback.
+export const fileSearch = ({
+  dataStream,
+}: {
+  dataStream: StreamWriter;
+}) => {
+  // dataStream reserved for parity with other tools (future streaming updates)
+  void dataStream;
+
+  return openai.tools.fileSearch({
+    vectorStoreIds: [
+      process.env.OPENAI_VECTORSTORE_ID ||
+        'vs_68c6a2b65df88191939f503958af019e',
+    ],
+    maxNumResults: 10,
+    ranking: { ranker: 'auto' },
+  });
+};
+

--- a/lib/ai/tools/tools-definitions.ts
+++ b/lib/ai/tools/tools-definitions.ts
@@ -6,6 +6,11 @@ export const toolsDefinitions: Record<ToolName, ToolDefinition> = {
     description: 'Get the weather in a specific location',
     cost: 1,
   },
+  fileSearch: {
+    name: 'fileSearch',
+    description: 'Search files via OpenAI vector store',
+    cost: 2,
+  },
   createDocument: {
     name: 'createDocument',
     description: 'Create a new document',

--- a/lib/ai/tools/tools.ts
+++ b/lib/ai/tools/tools.ts
@@ -13,6 +13,7 @@ import { generateImage } from '@/lib/ai/tools/generate-image';
 import type { ModelId } from '@/lib/models/model-id';
 import type { StreamWriter } from '../types';
 import { deepResearch } from './deep-research/deep-research';
+import { fileSearch } from '@/lib/ai/tools/file-search';
 
 export function getTools({
   dataStream,
@@ -33,6 +34,7 @@ export function getTools({
 }) {
   return {
     getWeather,
+    fileSearch: fileSearch({ dataStream }),
     createDocument: createDocumentTool({
       session,
       dataStream,

--- a/lib/ai/types.ts
+++ b/lib/ai/types.ts
@@ -9,6 +9,7 @@ import type { tavilyWebSearch } from '@/lib/ai/tools/web-search';
 import type { stockChart } from '@/lib/ai/tools/stock-chart';
 import type { codeInterpreter } from '@/lib/ai/tools/code-interpreter';
 import type { retrieve } from '@/lib/ai/tools/retrieve';
+import type { fileSearch } from '@/lib/ai/tools/file-search';
 import type {
   InferUITool,
   UIMessage,
@@ -24,6 +25,7 @@ import type { ModelId } from '../models/model-id';
 
 export const toolNameSchema = z.enum([
   'getWeather',
+  'fileSearch',
   'createDocument',
   'updateDocument',
   'requestSuggestions',
@@ -45,6 +47,7 @@ export const frontendToolsSchema = z.enum([
   'deepResearch',
   'generateImage',
   'createDocument',
+  'fileSearch',
 ]);
 
 const __ = frontendToolsSchema.options satisfies ToolNameInternal[];
@@ -74,6 +77,7 @@ type webSearchTool = InferUITool<ReturnType<typeof tavilyWebSearch>>;
 type stockChartTool = InferUITool<typeof stockChart>;
 type codeInterpreterTool = InferUITool<typeof codeInterpreter>;
 type retrieveTool = InferUITool<typeof retrieve>;
+type fileSearchTool = InferUITool<ReturnType<typeof fileSearch>>;
 
 export type ChatTools = {
   getWeather: weatherTool;
@@ -87,6 +91,7 @@ export type ChatTools = {
   stockChart: stockChartTool;
   codeInterpreter: codeInterpreterTool;
   retrieve: retrieveTool;
+  fileSearch: fileSearchTool;
 };
 
 export type CustomUIDataTypes = {

--- a/lib/types/anonymous.ts
+++ b/lib/types/anonymous.ts
@@ -40,6 +40,7 @@ export const ANONYMOUS_LIMITS = {
     'createDocument',
     'updateDocument',
     'retrieve',
+    'fileSearch',
     'webSearch',
     'stockChart',
     'codeInterpreter',


### PR DESCRIPTION
## Summary
- Introduces a new file search tool leveraging OpenAI's vector store capabilities
- Adds default support for the file search tool in the chat API and model provider options
- Updates environment variables to include `OPENAI_VECTORSTORE_ID` for configuration
- Extends tool definitions, types, and anonymous user limits to include file search

## Changes

### Core Functionality
- Created `fileSearch` tool wrapper in `lib/ai/tools/file-search.ts` using OpenAI vector store
- Integrated `fileSearch` tool into the main tools export and type definitions
- Updated model provider options to include `fileSearch` tool by default for OpenAI models
- Modified chat API route to recognize and enable `fileSearch` tool automatically when tools are active

### Configuration
- Added `OPENAI_VECTORSTORE_ID` to `.env.example` with a default vector store ID

### Tooling and Types
- Added `fileSearch` to `toolsDefinitions` with description and cost
- Extended `toolNameSchema` and `frontendToolsSchema` to include `fileSearch`
- Updated anonymous user limits to allow usage of `fileSearch`

## Test plan
- [x] Verify file search tool is available and enabled by default in chat API
- [x] Confirm environment variable fallback works correctly
- [x] Test file search tool integration with OpenAI vector store
- [x] Validate type and schema updates for tool inclusion
- [x] Ensure anonymous users can access file search functionality

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/51f59a9c-ac39-489c-942e-b3c3eafb97e3